### PR TITLE
Add WebGPU and Metal entries + GPU API reference table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Claude Code Instructions
+
+## Git Workflow
+
+- Always **squash-merge** PRs into `main` (use `gh pr merge --squash --delete-branch`).
+- Branch naming convention: `phase/<N>-<slug>` for phased content additions; `add/<org-repo>` for single-entry additions.

--- a/README.md
+++ b/README.md
@@ -34,21 +34,47 @@
 
 ## What Is Client-Side GPU Proving?
 
-<!-- Section content added in later phases -->
+Zero-knowledge proof systems require heavy arithmetic over finite fields and elliptic curves — operations that map naturally onto GPU parallelism. Traditionally, GPU acceleration was the domain of data-centre CUDA clusters. **Client-side GPU proving** brings the same speedups to ordinary user hardware: a browser tab, a smartphone, a laptop. This enables privacy-preserving applications that do not need to trust a remote server with sensitive inputs.
+
+The two most impactful operations targeted by this list are:
+
+- **MSM (Multi-Scalar Multiplication):** the dominant cost in pairing-based proof systems (Groth16, PLONK, etc.).
+- **NTT (Number Theoretic Transform):** the core of STARK and FRI-based systems.
+
+Both can achieve 10–100× speedups over CPU implementations when vectorised on modern GPU hardware.
 
 ## GPU API Quick-Reference
 
-<!-- Table content added in later phases -->
+| API | Platforms | Primary Languages | Browser Support | Notes |
+|-----|-----------|-------------------|-----------------|-------|
+| **WebGPU** | Browser, native (via `wgpu`) | WGSL, Rust, JS/TS | Chrome 113+, Firefox (flag), Safari TP | W3C standard; replaces WebGL for compute |
+| **Metal** | iOS, macOS, Apple Silicon | MSL, Rust (metal-rs), Swift | No | 2–3× faster than OpenGL on Apple hardware |
+| **Vulkan Compute** | Windows, Linux, Android | GLSL, SPIR-V, Rust | No | Cross-vendor; lowest-level portable API |
+| **ROCm / HIP** | AMD GPUs (Linux) | HIP C++ | No | CUDA-compatible syntax; growing mobile support |
+| **CUDA** | NVIDIA GPUs | CUDA C++ | No | Highest throughput; server/desktop only |
+| **OpenCL** | Most GPUs | OpenCL C | No | Legacy; being superseded by Vulkan/WebGPU |
 
 ## Projects by GPU Technology
 
 ### WebGPU (Browser-Native)
 
-<!-- Entries added in Phase 2 -->
+- [ICME-Lab/msm-webgpu](https://github.com/ICME-Lab/msm-webgpu) - WebGPU-accelerated MSM over BN254 using the cuZK algorithm, implemented in Rust and compiled to WGSL shaders. `GPU: WebGPU` `Curve: BN254` `Op: MSM` `Lang: Rust`
+
+- [td-kwj-zp2023/webgpu-msm-bls12-377](https://github.com/td-kwj-zp2023/webgpu-msm-bls12-377) - Winning ZPrize 2023 entry for WebGPU MSM over BLS12-377, achieving top performance in the browser-native competition. `GPU: WebGPU` `Curve: BLS12-377` `Op: MSM` `Lang: TypeScript`
+
+- [td-kwj-zp2023/webgpu-msm-twisted-edwards](https://github.com/td-kwj-zp2023/webgpu-msm-twisted-edwards) - ZPrize 2023 WebGPU MSM entry targeting Twisted Edwards curves, demonstrating efficient extended-coordinates arithmetic in WGSL. `GPU: WebGPU` `Curve: BLS12-377` `Op: MSM` `Lang: TypeScript`
+
+- [demox-labs/webgpu-crypto](https://github.com/demox-labs/webgpu-crypto) - Research-stage WebGPU library covering MSM, NTT, and hash functions over BLS12-377 and BN254. `GPU: WebGPU` `Curve: BLS12-377` `Curve: BN254` `Op: MSM` `Op: NTT` `Op: Hash` `Lang: TypeScript`
+
+- [demox-labs/webgpu-msm](https://github.com/demox-labs/webgpu-msm) - Baseline ZPrize 2023 reference framework for browser-native MSM over BLS12-377, used as a starting point by competition entrants. `GPU: WebGPU` `Curve: BLS12-377` `Op: MSM` `Lang: TypeScript`
+
+- [penumbra-zone/webgpu](https://github.com/penumbra-zone/webgpu) - Pioneer WebGPU Groth16 prover for Penumbra's shielded transactions over BLS12-377; archived after proving the concept. `GPU: WebGPU` `Curve: BLS12-377` `Op: Groth16` `Lang: Rust` `Status: Archived`
 
 ### Metal (Apple Silicon / iOS / macOS)
 
-<!-- Entries added in Phase 2 -->
+- [zkmopro/gpu-acceleration](https://github.com/zkmopro/gpu-acceleration) - Metal MSM library for Apple Silicon achieving 40–100× speedup over ARM CPU, integrated into the mopro mobile proving toolkit. `GPU: Metal` `Curve: BN254` `Op: MSM` `Lang: Rust`
+
+- [geometryxyz/msl-secp256k1](https://github.com/geometryxyz/msl-secp256k1) - Metal Shading Language implementation of secp256k1 elliptic-curve arithmetic using Jacobian coordinates, targeting Apple Silicon GPUs. `GPU: Metal` `Curve: secp256k1` `Op: EC Arithmetic` `Lang: MSL`
 
 ### Vulkan / ROCm / HIP (Cross-Platform Native)
 


### PR DESCRIPTION
## Summary

- Fills in the "What Is Client-Side GPU Proving?" intro section
- Adds GPU API quick-reference table (WebGPU, Metal, Vulkan, ROCm, CUDA, OpenCL)
- Adds 6 WebGPU project entries: ICME-Lab msm-webgpu, ZPrize winners (td-kwj-zp2023 ×2), demox-labs (×2), penumbra pioneer
- Adds 2 Metal project entries: zkmopro/gpu-acceleration, geometryxyz/msl-secp256k1
- Adds CLAUDE.md documenting the squash-merge convention

## Test plan

- [ ] Verify all 8 GitHub URLs resolve
- [ ] Confirm each entry has at minimum a `GPU:` tag
- [ ] Check GPU API table renders correctly in GitHub Markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)